### PR TITLE
FEAT: Custom output path flag

### DIFF
--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { resolve, relative } from 'path';
 import { LogType, Source } from '../types';
-import { configFlag, defaultConfigFilename, defaultIgnoredSources } from '../settings';
+import { configFlag, defaultConfigFilename, defaultIgnoredSources, outputFlag } from '../settings';
 
 export function log(message: string, type: LogType = LogType.Raw) {
   const map = new Map([
@@ -41,6 +41,12 @@ export function getConfigurationPath(): string {
   const filePath = index > 0 && args[index + 1] || defaultConfigFilename;
 
   return resolve(getWorkingDirectory(), filePath);
+}
+
+export function getCustomOutputPath() {
+  const args = getArguments();
+  const index = args.findIndex(argument => argument === outputFlag);
+  return index > -1 && args[index + 1] && resolve(getWorkingDirectory(), args[index + 1]);
 }
 
 export function getArguments(): string[] {

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -43,7 +43,7 @@ export function getConfigurationPath(): string {
   return resolve(getWorkingDirectory(), filePath);
 }
 
-export function getCustomOutputPath() {
+export function getCustomOutputPath(): string {
   const args = getArguments();
   const index = args.findIndex(argument => argument === outputFlag);
   return index > -1 && args[index + 1] && resolve(getWorkingDirectory(), args[index + 1]);

--- a/src/core/loadConfiguration.ts
+++ b/src/core/loadConfiguration.ts
@@ -1,8 +1,14 @@
 import { resolve, dirname, isAbsolute, join } from 'path';
 import { existsSync } from 'fs';
-import { log, getConfigurationPath, getWorkingDirectory, getArguments, getCustomOutputPath } from './helpers';
 import { configFlag, defaultConfigFilename } from '../settings';
 import { Configuration, LogType } from '../types';
+import {
+  log,
+  getConfigurationPath,
+  getWorkingDirectory,
+  getArguments,
+  getCustomOutputPath
+} from './helpers';
 
 export default function loadConfiguration(): Configuration {
   const args = getArguments();
@@ -27,7 +33,7 @@ export default function loadConfiguration(): Configuration {
  * This methods ensures that "to" is an absolute path.
  */
 function resolveDestinationPath(config: Configuration): Configuration {
-  const destinationPath = getCustomOutputPath() || config.copy.to
+  const destinationPath = getCustomOutputPath() || config.copy.to;
   config.copy.to = resolve(dirname(getConfigurationPath()), destinationPath);
   return config;
 }

--- a/src/core/loadConfiguration.ts
+++ b/src/core/loadConfiguration.ts
@@ -1,6 +1,6 @@
 import { resolve, dirname, isAbsolute, join } from 'path';
 import { existsSync } from 'fs';
-import { log, getConfigurationPath, getWorkingDirectory, getArguments } from './helpers';
+import { log, getConfigurationPath, getWorkingDirectory, getArguments, getCustomOutputPath } from './helpers';
 import { configFlag, defaultConfigFilename } from '../settings';
 import { Configuration, LogType } from '../types';
 
@@ -27,7 +27,8 @@ export default function loadConfiguration(): Configuration {
  * This methods ensures that "to" is an absolute path.
  */
 function resolveDestinationPath(config: Configuration): Configuration {
-  config.copy.to = resolve(dirname(getConfigurationPath()), config.copy.to);
+  const destinationPath = getCustomOutputPath() || config.copy.to
+  config.copy.to = resolve(dirname(getConfigurationPath()), destinationPath);
   return config;
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,11 +1,11 @@
   // Command line argument used to provide custom config filename
 export const configFlag = '--config';
 
+// Command line argument used to provide custom path for a new project
+export const outputFlag = '--output';
+
 // Config filename used if one is not provided as an argument
 export const defaultConfigFilename = 'theme-utils.config.js';
-
-// Command line argument used to provide custom path for a new project
-export const outputFlag = '--outputDir';
 
 // List of glob paths ignored in source directories
 export const defaultIgnoredSources = [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,9 @@ export const configFlag = '--config';
 // Config filename used if one is not provided as an argument
 export const defaultConfigFilename = 'theme-utils.config.js';
 
+// Command line argument used to provide custom path for a new project
+export const outputFlag = '--outputDir';
+
 // List of glob paths ignored in source directories
 export const defaultIgnoredSources = [
   '.nuxt/**',

--- a/tests/core/loadConfiguration.spec.ts
+++ b/tests/core/loadConfiguration.spec.ts
@@ -61,12 +61,12 @@ describe('loadConfiguration', () => {
       resolveToTemp(mockArgvOutputPath)
     ];
 
-    const configuration = loadConfiguration()
+    const configuration = loadConfiguration();
     expect(configuration).toEqual(mockArgvOutputPathConfig);
 
-    configuration.copy.to = mockArgvConfig.copy.to
+    configuration.copy.to = mockArgvConfig.copy.to;
     process.argv = oldArguments;
-  })
+  });
 
   it('loads the default new project\'s directory if no --outputDir argument was provided', () => {
     const oldArguments = process.argv;
@@ -78,5 +78,5 @@ describe('loadConfiguration', () => {
 
     expect(loadConfiguration()).toEqual(mockArgvConfig);
     process.argv = oldArguments;
-  })
+  });
 });

--- a/tests/core/loadConfiguration.spec.ts
+++ b/tests/core/loadConfiguration.spec.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path';
 import loadConfiguration from '../../src/core/loadConfiguration';
-import { configFlag, defaultConfigFilename } from '../../src/settings';
+import { configFlag, defaultConfigFilename, outputFlag } from '../../src/settings';
 
 const getConfig = (to) => ({
   copy: {
@@ -12,8 +12,10 @@ const getConfig = (to) => ({
 const getConfigContent = (config) => `module.exports = ${ JSON.stringify(config) };`
 
 const mockArgvPath = 'argument.config.js';
+const mockArgvOutputPath = '/output'
 const mockArgvConfig = getConfig('/argument/to');
 const mockDefaultConfig = getConfig('/default/to');
+const mockArgvOutputPathConfig = getConfig(mockArgvOutputPath)
 
 jest.spyOn(process, 'cwd').mockImplementation(resolveToTemp);
 
@@ -48,4 +50,33 @@ describe('loadConfiguration', () => {
   it('loads default configuration file is no argument was provided', () => {
     expect(loadConfiguration()).toEqual(mockDefaultConfig);
   });
+
+  it('loads new project\'s directory from --outputDir argument', () => {
+    const oldArguments = process.argv;
+    process.argv = [
+      ...oldArguments,
+      configFlag,
+      resolveToTemp(mockArgvPath),
+      outputFlag,
+      resolveToTemp(mockArgvOutputPath)
+    ];
+
+    const configuration = loadConfiguration()
+    expect(configuration).toEqual(mockArgvOutputPathConfig);
+
+    configuration.copy.to = mockArgvConfig.copy.to
+    process.argv = oldArguments;
+  })
+
+  it('loads the default new project\'s directory if no --outputDir argument was provided', () => {
+    const oldArguments = process.argv;
+    process.argv = [
+      ...oldArguments,
+      configFlag,
+      resolveToTemp(mockArgvPath)
+    ];
+
+    expect(loadConfiguration()).toEqual(mockArgvConfig);
+    process.argv = oldArguments;
+  })
 });

--- a/tests/core/loadConfiguration.spec.ts
+++ b/tests/core/loadConfiguration.spec.ts
@@ -12,10 +12,10 @@ const getConfig = (to) => ({
 const getConfigContent = (config) => `module.exports = ${ JSON.stringify(config) };`
 
 const mockArgvPath = 'argument.config.js';
-const mockArgvOutputPath = '/output'
+const mockArgvOutputPath = '/output';
 const mockArgvConfig = getConfig('/argument/to');
 const mockDefaultConfig = getConfig('/default/to');
-const mockArgvOutputPathConfig = getConfig(mockArgvOutputPath)
+const mockArgvOutputPathConfig = getConfig(mockArgvOutputPath);
 
 jest.spyOn(process, 'cwd').mockImplementation(resolveToTemp);
 


### PR DESCRIPTION
I thought it might be a good idea to equip the package in another flag called `--outputDir`. We could provide a relative path to a directory of our choice through it. This way we'd have more control over where our new vsf project would be generated.

Currently achieving this is possible by changing the following line in `ct-config.js` from:

```
copy: {
    to: 'generated-ct',
}
```

to for example:
```
copy: {
    to: '../customer-repositories/my-new-customer-repository'
}
```

however, it is cumbersome to change it manually every time we want to generate a new project. It is also polluting our local branch with unneccessary changes that we have to omit every time we commit our changes. 

It would be nice to be able to point out the desired directory by simply adding it as a flag like this:
```
yarn vsf-tu --config ct-config.js --outputDir ../customer-repositories/my-new-customer-repository
```