### PR TITLE
feat: add 'ignoreParse' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 > **Disclaimer:** This project is still in beta phase.
 
 ## How it works
+
 This package creates a `vsf-tu` script allowing to extend multiple [Vue Storefront 2](https://github.com/vuestorefront/vue-storefront) themes by letting them inherit from each other.
 
 You can use it with any JavaScript application though. it does not require Vue or Nuxt to run.
@@ -38,11 +39,13 @@ Create a `theme-utils.config.js` file in the root of the project.
 // theme-utils.config.js
 module.exports = {
   copy: {
+    parseAllExtensions: false,
     to: '',
     from: [
       {
         path: '',
         ignore: [],
+        ignoreParse: [],
         variables: {},
         watch: true
       }
@@ -68,6 +71,7 @@ Alternatively you can use `--config path/to/config/file` flag to provide custom 
 - `from` Array of source directories:
   - `path` Path to source directory. Can be relative or absolute.
   - `ignore` Array of ignored files/paths. Paths are [glob](https://github.com/isaacs/node-glob)-compatible. Contents of `.nuxt` and `node_modules` are ignored by default.
+  - `ignoreParse` Array of files that shouldn't be parsed by `ejs`. It overrides `parseAllExtensions` and file extensions parsed by default.
   - `variables` Template variables resolved at build-time.
   - `watch` Whether directory should be watched for changes.
 

--- a/src/core/transformTemplate.ts
+++ b/src/core/transformTemplate.ts
@@ -5,21 +5,49 @@ import { log } from '../core/helpers';
 import { LogType, TransformTemplateParams } from '../types';
 import { templateFilesExtensions } from '../settings';
 
+/**
+ * Transforms template files and copy them to their destinations
+ */
 export default async function transformTemplate({ config, file, sourcePath }: TransformTemplateParams): Promise<void> {
-  const source = resolve(sourcePath, file);
-  const destination = resolve(config.copy.to, file);
+  const source = config.copy.from.find(source => source.path === sourcePath);
+  const filePath = resolve(sourcePath, file);
+  const destinationPath = resolve(config.copy.to, file);
 
-  mkdirSync(dirname(destination), { recursive: true });
+  mkdirSync(dirname(destinationPath), { recursive: true });
+
+  /**
+   * If file is a template, parse it and write it to the destination.
+   */
+  async function parseAndWriteFile() {
+    return writeFileSync(
+      destinationPath,
+      await parseTemplate({ config, file: filePath, sourcePath })
+    );
+  }
+
+  /**
+   * If file is not a template, copy it to the destination.
+   */
+  function copyFile() {
+    return copyFileSync(filePath, destinationPath);
+  }
+
+  if (source.ignoreParse?.includes(filePath)) {
+    return copyFile();
+  }
 
   if (config.copy.parseAllExtensions) {
-    return writeFileSync(destination, await parseTemplate({ config, file: source, sourcePath }));
+    return parseAndWriteFile();
   }
 
   return templateFilesExtensions.includes(extname(file))
-    ? writeFileSync(destination, await parseTemplate({ config, file: source, sourcePath }))
-    : copyFileSync(source, destination);
+    ? parseAndWriteFile()
+    : copyFile();
 }
 
+/**
+ * Parses template file and returns its content.
+ */
 async function parseTemplate({ config, file, sourcePath }: TransformTemplateParams): Promise<string> {
   const source = config.copy.from.find(source => source.path === sourcePath);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,9 @@
 export interface Source {
   path: string;
-  ignore: string[];
-  variables: Record<string, any>;
-  watch: boolean;
+  ignore?: string[];
+  ignoreParse?: string[];
+  variables?: Record<string, any>;
+  watch?: boolean;
 }
 
 export interface Configuration {

--- a/tests/core/transformTemplate.spec.ts
+++ b/tests/core/transformTemplate.spec.ts
@@ -23,6 +23,7 @@ describe('transformTemplate', () => {
     createFile(`${directory}/script.js`, templateFileContent);
     createFile(`${directory}/script.ts`, templateFileContent);
     createFile(`${directory}/config.json`, templateFileContent);
+    createFile(`${directory}/ignored.js`, staticFileContent);
   });
 
   afterAll(() => {
@@ -99,7 +100,7 @@ describe('transformTemplate', () => {
     expect(itemContent(destination)).toBe(compiledContent);
   });
 
-  it('compiles each file to destination if compileEachFile is true', async () => {
+  it('compiles each file to destination if parseAllExtensions is true', async () => {
     const filename = 'TESTING.md';
     const destination = `${config.copy.to}/${filename}`;
 
@@ -117,5 +118,30 @@ describe('transformTemplate', () => {
 
     expect(itemExists(destination)).toBeTruthy();
     expect(itemContent(destination)).toBe(compiledContent);
+  });
+
+  it('doesn\'t compile files specified in ignoreParse', async () => {
+    const filename = 'ignored.js';
+    const destination = `${config.copy.to}/${filename}`;
+
+    await transformTemplate({
+      config: {
+        ...config,
+        copy: {
+          ...config.copy,
+          from: [
+            {
+              ...config.copy.from[0],
+              ignoreParse: [`${directory}/${filename}`]
+            }
+          ]
+        }
+      },
+      file: filename,
+      sourcePath: directory
+    });
+
+    expect(itemExists(destination)).toBeTruthy();
+    expect(itemContent(destination)).toBe(staticFileContent);
   });
 });


### PR DESCRIPTION
This PR adds the `ignoreParse` option, which allows specifying files that shouldn't be parsed by `ejs`. Files in this array will not be parsed even when `parseAllExtensions` is `true` or if its file extension is parsed by default.

Fixes #18 